### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ django-cruds
 .. image:: https://coveralls.io/repos/bmihelac/django-cruds/badge.png?branch=master
     :target: https://coveralls.io/r/bmihelac/django-cruds?branch=master
 
-.. image:: https://pypip.in/v/django-cruds/badge.png   
+.. image:: https://img.shields.io/pypi/v/django-cruds.svg   
     :target: https://crate.io/packages/django-cruds
 
 django-cruds is simple drop-in django app that creates CRUD


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-cruds))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-cruds`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.